### PR TITLE
Delete 'poll()' recursion call in stream

### DIFF
--- a/lib/src/stream.rs
+++ b/lib/src/stream.rs
@@ -1,6 +1,6 @@
 use std::{cmp::max, collections::VecDeque, time::Duration};
 
-use futures::{Async, Future, Poll, Stream};
+use futures::{Async, Future, Poll, Stream, task};
 use tokio_timer;
 
 use telegram_bot_fork_raw::{AllowedUpdate, GetUpdates, Integer, Update};
@@ -58,6 +58,7 @@ impl Stream for UpdatesStream {
         match result {
             Ok(true) => {
                 self.current_request = None;
+                task::current().notify();
                 Ok(Async::NotReady)
             }
             Ok(false) => {
@@ -73,6 +74,7 @@ impl Stream for UpdatesStream {
                 );
 
                 self.current_request = Some(request);
+                task::current().notify();
                 Ok(Async::NotReady)
             }
             Err(err) => {

--- a/lib/src/stream.rs
+++ b/lib/src/stream.rs
@@ -58,7 +58,7 @@ impl Stream for UpdatesStream {
         match result {
             Ok(true) => {
                 self.current_request = None;
-                self.poll()
+                Ok(Async::NotReady)
             }
             Ok(false) => {
                 let timeout = self.timeout + Duration::from_secs(1);
@@ -73,7 +73,7 @@ impl Stream for UpdatesStream {
                 );
 
                 self.current_request = Some(request);
-                self.poll()
+                Ok(Async::NotReady)
             }
             Err(err) => {
                 let timeout_future = tokio_timer::sleep(self.error_delay)


### PR DESCRIPTION
It allows to avoid `thread 'main' has overflowed its stack' error