### PR TITLE
Add send_document to modules

### DIFF
--- a/lib/src/prelude.rs
+++ b/lib/src/prelude.rs
@@ -8,8 +8,9 @@ pub use telegram_bot_fork_raw::{
     CanGetChatAdministrators, CanGetChatMemberForChat, CanGetChatMemberForUser,
     CanGetChatMembersCount, CanGetFile, CanGetUserProfilePhotos, CanKickChatMemberForChat,
     CanKickChatMemberForUser, CanLeaveChat, CanPinMessage, CanReplySendAudio, CanReplySendContact,
-    CanReplySendLocation, CanReplySendMessage, CanReplySendVenue, CanSendAudio, CanSendChatAction,
-    CanSendContact, CanSendLocation, CanSendMessage, CanSendVenue, CanStopMessageLiveLocation,
-    CanUnbanChatMemberForChat, CanUnbanChatMemberForUser, CanUnpinMessage, ToReplyRequest,
-    ToRequest, ExportChatInviteLink, CanExportChatInviteLink,
+    CanReplySendDocument, CanReplySendLocation, CanReplySendMessage, CanReplySendVenue,
+    CanSendAudio, CanSendChatAction, CanSendContact, CanSendDocument, CanSendLocation,
+    CanSendMessage, CanSendVenue, CanStopMessageLiveLocation, CanUnbanChatMemberForChat,
+    CanUnbanChatMemberForUser, CanUnpinMessage, ToReplyRequest, ToRequest, ExportChatInviteLink,
+    CanExportChatInviteLink,
 };

--- a/lib/src/types/requests.rs
+++ b/lib/src/types/requests.rs
@@ -5,6 +5,6 @@ pub use telegram_bot_fork_raw::{
     EditMessageReplyMarkup, EditMessageText, ForwardMessage, GetChat, GetChatAdministrators,
     GetChatMember, GetChatMembersCount, GetFile, GetMe, GetUpdates, GetUserProfilePhotos,
     KickChatMember, LeaveChat, PinChatMessage, RestrictChatMember, SendAudio, SendChatAction,
-    SendContact, SendLocation, SendMessage, SendVenue, StopMessageLiveLocation, UnbanChatMember,
-    UnpinChatMessage, ExportChatInviteLink, CanExportChatInviteLink,
+    SendContact, SendDocument, SendLocation, SendMessage, SendVenue, StopMessageLiveLocation,
+    UnbanChatMember, UnpinChatMessage, ExportChatInviteLink, CanExportChatInviteLink,
 };

--- a/raw/src/requests/mod.rs
+++ b/raw/src/requests/mod.rs
@@ -21,6 +21,7 @@ pub mod restrict_chat_member;
 pub mod send_audio;
 pub mod send_chat_action;
 pub mod send_contact;
+pub mod send_document;
 pub mod send_location;
 pub mod send_message;
 pub mod send_venue;
@@ -35,7 +36,7 @@ pub use self::{
     forward_message::*, get_chat::*, get_chat_administrators::*, get_chat_member::*,
     get_chat_members_count::*, get_file::*, get_me::*, get_updates::*, get_user_profile_photos::*,
     kick_chat_member::*, leave_chat::*, pin_chat_message::*, restrict_chat_member::*,
-    send_audio::*, send_chat_action::*, send_contact::*, send_location::*, send_message::*,
+    send_audio::*, send_chat_action::*, send_contact::*, send_document::*, send_location::*, send_message::*,
     send_venue::*, stop_message_live_location::*, unban_chat_member::*, unpin_chat_message::*,
     export_chat_invite_link::*
 };

--- a/raw/src/requests/send_document.rs
+++ b/raw/src/requests/send_document.rs
@@ -8,7 +8,7 @@ use requests::*;
 /// Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Serialize)]
 #[must_use = "requests do nothing unless sent"]
-pub struct SendDocument<'s, 'c, 'p, 't> {
+pub struct SendDocument<'s, 'c> {
     chat_id: ChatRef,
     document: Cow<'s, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -23,7 +23,7 @@ pub struct SendDocument<'s, 'c, 'p, 't> {
     reply_markup: Option<ReplyMarkup>,
 }
 
-impl<'s, 'c, 'p, 't> Request for SendDocument<'s, 'c, 'p, 't> {
+impl<'s, 'c> Request for SendDocument<'s, 'c> {
     type Type = JsonRequestType<Self>;
     type Response = JsonTrueToUnitResponse;
 
@@ -32,7 +32,7 @@ impl<'s, 'c, 'p, 't> Request for SendDocument<'s, 'c, 'p, 't> {
     }
 }
 
-impl<'s, 'c, 'p, 't> SendDocument<'s, 'c, 'p, 't> {
+impl<'s, 'c> SendDocument<'s, 'c> {
     pub fn with_url<C, T>(chat: C, url: T) -> Self
     where
         C: ToChatRef,
@@ -81,7 +81,7 @@ impl<'s, 'c, 'p, 't> SendDocument<'s, 'c, 'p, 't> {
 
 /// Can reply with a document
 pub trait CanReplySendDocument {
-    fn document_url_reply<'s, 'c, 'p, 't, T>(&self, url: T) -> SendDocument<'s, 'c, 'p, 't>
+    fn document_url_reply<'s, 'c, T>(&self, url: T) -> SendDocument<'s, 'c>
     where
         T: Into<Cow<'s, str>>;
 }
@@ -90,7 +90,7 @@ impl<M> CanReplySendDocument for M
 where
     M: ToMessageId + ToSourceChat,
 {
-    fn document_url_reply<'s, 'c, 'p, 't, T>(&self, url: T) -> SendDocument<'s, 'c, 'p, 't>
+    fn document_url_reply<'s, 'c, T>(&self, url: T) -> SendDocument<'s, 'c>
     where
         T: Into<Cow<'s, str>>,
     {
@@ -102,7 +102,7 @@ where
 
 /// Send an audio
 pub trait CanSendDocument {
-    fn document_url<'s, 'c, 'p, 't, T>(&self, url: T) -> SendDocument<'s, 'c, 'p, 't>
+    fn document_url<'s, 'c, T>(&self, url: T) -> SendDocument<'s, 'c>
     where
         T: Into<Cow<'s, str>>;
 }
@@ -111,7 +111,7 @@ impl<M> CanSendDocument for M
 where
     M: ToChatRef,
 {
-    fn document_url<'s, 'c, 'p, 't, T>(&self, url: T) -> SendDocument<'s, 'c, 'p, 't>
+    fn document_url<'s, 'c, T>(&self, url: T) -> SendDocument<'s, 'c>
     where
         T: Into<Cow<'s, str>>,
     {


### PR DESCRIPTION
Previously it was not possible to send documents as the module
was not included in the library. This commit fixes #9.