### PR TITLE
Ignore forward-type of forwarded message if author is private

### DIFF
--- a/raw/src/types/message.rs
+++ b/raw/src/types/message.rs
@@ -228,7 +228,7 @@ impl Message {
             &raw.forward_from_chat,
             raw.forward_from_message_id,
         ) {
-            (None, &None, &None, None) => None,
+            (None, &None, &None, _) => None,
             (Some(date), from, &None, None) => Some(Forward {
                 date,
                 from: ForwardFrom::User { user: from.clone() },
@@ -360,7 +360,7 @@ impl ChannelPost {
             &raw.forward_from_chat,
             raw.forward_from_message_id,
         ) {
-            (None, &None, &None, None) => None,
+            (None, &None, &None, _) => None,
             (Some(date), from, &None, None) => Some(Forward {
                 date,
                 from: ForwardFrom::User { user: from.clone() },


### PR DESCRIPTION
If a message is forwarded to a group, channel or other conversation, and the original author has marked their profile as hidden, no origin user, channel or group is attached to the forwarding-metadata.

In order to mitigate crashes (as we are facing), this counts messages without valid forward metadata as non-forwarded.